### PR TITLE
Use major version ref in example snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ To get the action's default version of Task just add this step:
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@main
+  uses: arduino/setup-task@v1
 ```
 
 If you want to pin a major or minor version you can use the `.x` wildcard:
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@main
+  uses: arduino/setup-task@v1
   with:
     version: 2.x
 ```
@@ -51,7 +51,7 @@ To pin the exact version:
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@main
+  uses: arduino/setup-task@v1
   with:
     version: 2.6.1
 ```


### PR DESCRIPTION
Previously, due to the lack of a release, the only option was to use the default branch name for the action ref. Using
release versions provides a more stable experience for the ordinary users of these actions and also eases ongoing
development work on the actions.

Use of the major version ref will cause the workflow to benefit from ongoing development to the action at each patch or
minor release up until such time as a new major release is made, at which time the user will be given the opportunity
to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release
before manually updating the major ref (e.g., `uses: arduino/setup-task@v2`).