### PR TITLE
Use new action name in CI workflows

### DIFF
--- a/.github/workflows/check-action-metadata-task.yml
+++ b/.github/workflows/check-action-metadata-task.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -42,7 +42,7 @@ jobs:
         uses: xt0rted/markdownlint-problem-matcher@v1
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-typescript-task.yml
+++ b/.github/workflows/check-typescript-task.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -27,7 +27,7 @@ jobs:
         run: pip install poetry
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/test-typescript-task.yml
+++ b/.github/workflows/test-typescript-task.yml
@@ -53,7 +53,7 @@ jobs:
           node-version: 12.x
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -74,7 +74,7 @@ jobs:
           node-version: 12.x
 
       - name: Install Task
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
This useful action is an integral part of the project's own CI system. Now that it has a dedicated repository and a new name, the CI
workflows must be updated to use the latest release version of the action.