### PR TITLE
Print installed Task version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -195,6 +195,7 @@ function getTask(version, repoToken) {
         }
         toolPath = path.join(toolPath, "bin");
         core.addPath(toolPath);
+        core.info(`Successfully setup Task version ${targetVersion}`);
     });
 }
 exports.getTask = getTask;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -195,4 +195,5 @@ export async function getTask(version: string, repoToken: string) {
 
   toolPath = path.join(toolPath, "bin");
   core.addPath(toolPath);
+  core.info(`Successfully setup Task version ${targetVersion}`);
 }


### PR DESCRIPTION
Currently, if users set a version range (e.g. `3.x`) they have no way to understand what Task version their CI actually ran by looking only at its logs. 

Printing the installed version is something other similar tools do (e.g. [actions/setup-go](https://github.com/actions/setup-go/blob/v2.1.4/src/main.ts#L35)) and that can be very useful in case of debugging.

As an example, in https://github.com/arduino/arduino-cli/pull/1576 it was hard to understand what broke the CI as from the logs it seemed that nothing had changed.