### PR TITLE
Prevent inappropriate `@types/node` bumps from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+    ignore:
+      - dependency-name: "@types/node"
+        # @types/node should be kept in sync with the major version of Node.js that is in use.
+        # So we only want automated updates for minor and patch releases of this dependency.
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: pip
     directory: /
     schedule:


### PR DESCRIPTION
The project has a dependency on the `@types/node` package. That package follows the major version of Node.js.

https://stackoverflow.com/questions/42035263/relationship-between-the-version-of-node-js-and-the-version-of-types-node

Since we are now using Node.js 16.x for the development of the project, we must also use the ^16.x series of `@types/node`.

Since there are 17.x versions of the `@types/node` package available, Dependabot would submit unwanted PRs to bump the dependency to those versions (e.g., https://github.com/arduino/setup-task/pull/295). This configuration prevents that. Dependabot will continue to submit PRs for bumps to any new minor or patch releases made within the current major version series.

Since this configuration prevents Dependabot from submitting major version bumps, The `@types/node` dependency version must be updated manually when we update to using a new major version of Node.js for the development of this project.

Reference:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore

---

Demonstration of the behavior of Dependabot under this configuration with an outdated version of the 16.x series of the dependency in use:
https://github.com/per1234/setup-task/pull/1
Note that it bumped to the latest version in the 16.x series: 16.11.19, even though there are newer versions available from the 17.x series.