### PR TITLE
Sync "Check npm" workflow with upstream

### DIFF
--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -41,8 +41,18 @@ jobs:
         with:
           # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
           file-url: https://json.schemastore.org/package.json
-          location: ${{ runner.temp }}/package-json-schema
+          location: ${{ runner.temp }}/json-schema
           file-name: package-json-schema.json
+
+      # This schema is referenced by the package.json schema, so must also be accessible.
+      - name: Download JSON schema for eslintrc.json
+        id: download-referenced-schema
+        uses: carlosperate/download-file-action@v1
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
+          file-url: https://json.schemastore.org/eslintrc.json
+          location: ${{ runner.temp }}/json-schema
+          file-name: eslintrc-json-schema.json
 
       - name: Install JSON schema validator
         # package.json schema is draft-04, which is not supported by ajv-cli >=4.
@@ -53,6 +63,7 @@ jobs:
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
             -s "${{ steps.download-schema.outputs.file-path }}" \
+            -r "${{ steps.download-referenced-schema.outputs.file-path }}" \
             -d "./**/package.json"
 
   check-manifest:

--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -24,6 +24,9 @@ on:
   workflow_dispatch:
   repository_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A "Check npm" GitHub Actions workflow is used to check for problems with the repository's npm configuration files.

This workflow is based on one hosted and maintained in a repository dedicated to a collection of such reusable assets.

Several enhancements have been made to the upstream file, but those had not yet been pulled into this repository:

- Restrict permissions of `GITHUB_TOKEN`
  https://github.com/per1234/.github/commit/110526423b2fb08f0145f604bcc11c3d2ee4fe77
- Install referenced schema
  https://github.com/per1234/.github/commit/61d9f9b8e23d17917ffbdfee3fa1b89ecbc673f8