### PR TITLE
Install referenced schema in "Check npm" workflow

### DIFF
--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -46,13 +46,23 @@ jobs:
 
       # This schema is referenced by the package.json schema, so must also be accessible.
       - name: Download JSON schema for eslintrc.json
-        id: download-referenced-schema
+        id: download-eslintrc-schema
         uses: carlosperate/download-file-action@v1
         with:
           # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
           file-url: https://json.schemastore.org/eslintrc.json
           location: ${{ runner.temp }}/json-schema
-          file-name: eslintrc-json-schema.json
+          file-name: eslintrc-schema.json
+
+      # This schema is referenced by the package.json schema, so must also be accessible.
+      - name: Download JSON schema for eslintrc.json
+        id: download-prettierrc-schema
+        uses: carlosperate/download-file-action@v1
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/prettierrc.json
+          file-url: https://json.schemastore.org/prettierrc.json
+          location: ${{ runner.temp }}/json-schema
+          file-name: prettierrc-schema.json
 
       - name: Install JSON schema validator
         # package.json schema is draft-04, which is not supported by ajv-cli >=4.
@@ -63,7 +73,8 @@ jobs:
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
             -s "${{ steps.download-schema.outputs.file-path }}" \
-            -r "${{ steps.download-referenced-schema.outputs.file-path }}" \
+            -r "${{ steps.download-eslintrc-schema.outputs.file-path }}" \
+            -r "${{ steps.download-prettierrc-schema.outputs.file-path }}" \
             -d "./**/package.json"
 
   check-manifest:


### PR DESCRIPTION
The "Check npm" GitHub Actions workflow validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the `$ref` keyword. The `package.json` schema was recently updated to share resources with the `prettierrc.json` schema, which caused the validation to start failing:

```text
schema /home/runner/work/_temp/json-schema/package-json-schema.json is invalid
error: can't resolve reference https://json.schemastore.org/prettierrc.json from id #
```

The solution is to configure the workflow to download that schema as well and also to provide its path to the avj-cli validator via an `-r` flag.