### PR TITLE
Install referenced schemas in "Check npm" workflow

### DIFF
--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -65,7 +65,7 @@ jobs:
           file-name: eslintrc-schema.json
 
       # This schema is referenced by the package.json schema, so must also be accessible.
-      - name: Download JSON schema for eslintrc.json
+      - name: Download JSON schema for Prettier configuration file
         id: download-prettierrc-schema
         uses: carlosperate/download-file-action@v1
         with:

--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -74,6 +74,26 @@ jobs:
           location: ${{ runner.temp }}/json-schema
           file-name: prettierrc-schema.json
 
+      # This schema is referenced by the package.json schema, so must also be accessible.
+      - name: Download JSON schema for semantic-release
+        id: download-semantic-release-schema
+        uses: carlosperate/download-file-action@v1
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
+          file-url: https://json.schemastore.org/semantic-release.json
+          location: ${{ runner.temp }}/json-schema
+          file-name: semantic-release-schema.json
+
+      # This schema is referenced by the package.json schema, so must also be accessible.
+      - name: Download JSON schema for .stylelintrc
+        id: download-stylelintrc-schema
+        uses: carlosperate/download-file-action@v1
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
+          file-url: https://json.schemastore.org/stylelintrc.json
+          location: ${{ runner.temp }}/json-schema
+          file-name: stylelintrc-schema.json
+
       - name: Install JSON schema validator
         # package.json schema is draft-04, which is not supported by ajv-cli >=4.
         run: sudo npm install --global ajv-cli@3.x
@@ -86,6 +106,8 @@ jobs:
             -r "${{ steps.download-ava-schema.outputs.file-path }}" \
             -r "${{ steps.download-eslintrc-schema.outputs.file-path }}" \
             -r "${{ steps.download-prettierrc-schema.outputs.file-path }}" \
+            -r "${{ steps.download-semantic-release-schema.outputs.file-path }}" \
+            -r "${{ steps.download-stylelintrc-schema.outputs.file-path }}" \
             -d "./**/package.json"
 
   check-manifest:


### PR DESCRIPTION
The "Check npm" GitHub Actions workflow validates the repository's `package.json` npm manifest file against its JSON
schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the `$ref` keyword. The
`package.json` schema was recently updated to share resources with the `.stylelintrc` and semantic-release configuration
schemas, which caused the validation to
start failing:

```
schema /home/runner/work/_temp/json-schema/package-json-schema.json is invalid
error: can't resolve reference https://json.schemastore.org/stylelintrc.json from id #
```

The solution is to configure the workflow to download that schema as well and also to provide its path to the avj-cli
validator via an `-r` flag.
