### PR TITLE
Use appropriate file name for TypeScript config file when validating

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -217,7 +217,7 @@ tasks:
       WORKING_FOLDER:
         sh: task utility:mktemp-folder TEMPLATE="ts-validate-XXXXXXXXXX"
       WORKING_INSTANCE_PATH:
-        sh: echo "{{.WORKING_FOLDER}}/$(basename "{{.SCHEMA_PATH}}")"
+        sh: echo "{{.WORKING_FOLDER}}/$(basename "{{.INSTANCE_PATH}}")"
     cmds:
       - |
         # TypeScript allows comments in tsconfig.json.


### PR DESCRIPTION
The `ts:validate` task validates the repository's TypeScript configuration files against [their JSON schema](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#schema).

The `tsconfig.json` file contains comments, which are not supported by the version of [the JSON schema validator tool](https://ajv.js.org/packages/ajv-cli.html) in use. The comments are removed by the task and the cleaned data written to a temporary file.

Previously, the wrong [taskfile variable](https://taskfile.dev/usage/#dynamic-variables) was used in the command that generates the filename of that temporary file, resulting in it having a different filename than intended. This has no functional effect on the validation results, which are solely based on the content of the file and not its name, however, it makes the validation results confusing to the humans reading the logs.

For example, previously a successful validation produced output with this form:

https://github.com/arduino/setup-task/runs/7855086350?check_suite_focus=true#step:5:26

```text
/tmp/ts-validate-yVxglvosn8/tsconfig-schema-yviXnDDlRy.json valid
```

The change to using the correct taskfile variable in the command made here results in output in the expected form:

https://github.com/arduino/setup-task/runs/7878614458?check_suite_focus=true#step:5:26

```text
/tmp/ts-validate-MHMcc008KG/tsconfig.json valid
```