### PR TITLE
Bump Node version from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     required: false
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
GitHub is migrating all actions from Node 12 to Node 16 and is raising warnings for actions still using Node 12. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Update the version accordingly.