### PR TITLE
Fix link to Node.js installation downloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ https://taskfile.dev/#/installation
 [**npm**](https://www.npmjs.com/) is used for dependency management.
 
 Follow the installation instructions here:<br />
-https://nodejs.dev/download
+https://nodejs.dev/en/download
 
 Node.js 16.x is used for development of this project. [nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
 


### PR DESCRIPTION
The contributor guide documents the project's dependency on Node.js/npm and provides a link to facilitate the installation for contributors who don't have it already.

That link recently stopped working. It seems that the nodejs.dev website now requires the locale component in URL paths. Ideally, localization should be avoided in documentation links and the target website redirect the generalized URL to the localized page according to the visitor's locale configuration. Unfortunately this is no longer supported by the Node.js website.

In order to fix it, the link is changed to using a localized URL, with English selected due to being the project's base language.