### PR TITLE
Add support for all Task build architectures

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -146,8 +146,15 @@ function computeVersion(version, repoToken) {
     });
 }
 function getFileName() {
+    var _a;
     const platform = osPlat === "win32" ? "windows" : osPlat;
-    const arch = osArch === "x64" ? "amd64" : "386";
+    const arches = {
+        arm: "arm",
+        arm64: "arm64",
+        x64: "amd64",
+        ia32: "386",
+    };
+    const arch = (_a = arches[osArch]) !== null && _a !== void 0 ? _a : osArch;
     const ext = osPlat === "win32" ? "zip" : "tar.gz";
     const filename = util.format("task_%s_%s.%s", platform, arch, ext);
     return filename;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -136,7 +136,13 @@ async function computeVersion(
 
 function getFileName() {
   const platform: string = osPlat === "win32" ? "windows" : osPlat;
-  const arch: string = osArch === "x64" ? "amd64" : "386";
+  const arches = {
+    arm: "arm",
+    arm64: "arm64",
+    x64: "amd64",
+    ia32: "386",
+  };
+  const arch: string = arches[osArch] ?? osArch;
   const ext: string = osPlat === "win32" ? "zip" : "tar.gz";
   const filename: string = util.format("task_%s_%s.%s", platform, arch, ext);
 


### PR DESCRIPTION
Previously, the action could only install [**Task**](https://taskfile.dev/) when the GitHub Actions runner the [workflow](https://docs.github.com/actions/using-workflows/about-workflows) job was running on had an [x86-64](https://en.wikipedia.org/wiki/X86-64) or [i386](https://en.wikipedia.org/wiki/I386) architecture.

Since the GitHub-hosted runners are currently all x86-64, that is sufficient for most users. However, it is also possible to use GitHub actions with [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) of other architectures. [**Task** builds](https://github.com/go-task/task/releases) are available for more architectures, so the action's code unnecessarily limited its utility.

Support for all architectures with available builds is hereby added.

In order to provide some possibility of automatic support for additional builds that may become available in the future, if the action code does not contain a [mapped](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map) value for the host architecture, [the value from **Node.js**](https://nodejs.org/api/os.html#osarch) is used verbatim. Because the mapping between [the architecture value provided by **Node.js**](https://nodejs.org/api/os.html#osarch) to the filename suffix used in the [**Task** build archives](https://github.com/go-task/task/releases) is a bit confusing, I added mapping entries for all suffixes, even in the cases where the two values are equal.

---

In order to provide a demonstration of the newly added architectures in use, I did a run of the integration test workflow with a job added to run it on a self-hosted runner I provided on an Apple Silicon (ARM64) macOS machine:

https://github.com/per1234/setup-task/actions/runs/4030927386

Unfortunately, adding such coverage as a permanent part of the repository's architecture would be problematic because our current approach for producing such a runner ([AWS EC2](https://aws.amazon.com/ec2/) instance) incurs a significant charge to Arduino's AWS account for every workflow run. So I think we will need to be satisfied with the integration tests only providing coverage of the x86 runner architecture support and rely on manual/incidental testing for other runner architectures.