### PR TITLE
feat: Default `repo-token` to GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Can be an exact version (e.g., `3.4.2`) or a version range (e.g., `3.x`).
 
 [GitHub access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) used for GitHub API requests.
 
-**Default**: [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
+**Default**: [`GITHUB_TOKEN`](https://docs.github.com/actions/security-guides/automatic-token-authentication)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Can be an exact version (e.g., `3.4.2`) or a version range (e.g., `3.x`).
 
 ### `repo-token`
 
-(**Optional**) GitHub access token used for GitHub API requests.
-Heavy usage of the action can result in workflow run failures caused by rate limiting. GitHub provides a more generous allowance for Authenticated API requests.
+[GitHub access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) used for GitHub API requests.
 
-It will be convenient to use [`${{ secrets.GITHUB_TOKEN }}`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow).
+**Default**: [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
   repo-token:
     description: "Token with permissions to do repo things"
     required: false
+    default: "${{ github.token }}"
 
 runs:
   using: "node16"


### PR DESCRIPTION
The absence of a default value for  `repo-token` means that this action may start to fail long after it has been implemented by a developer: the developer adds the action to their workflow (without a token because it's optional) and then, at some point in the future, their workflows may *randomly* start to fail because they've hit the unauthenticated rate-limit.