### PR TITLE
Bump node from 16 to 20

### DIFF
--- a/.github/workflows/check-action-metadata-task.yml
+++ b/.github/workflows/check-action-metadata-task.yml
@@ -2,7 +2,7 @@ name: Check Action Metadata
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
+  NODE_VERSION: 20.x
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -3,7 +3,7 @@ name: Check npm Dependencies
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
+  NODE_VERSION: 20.x
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -3,7 +3,7 @@ name: Check Prettier Formatting
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
+  NODE_VERSION: 20.x
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-typescript-task.yml
+++ b/.github/workflows/check-typescript-task.yml
@@ -2,7 +2,7 @@ name: Check TypeScript
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
+  NODE_VERSION: 20.x
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/test-typescript-task.yml
+++ b/.github/workflows/test-typescript-task.yml
@@ -2,7 +2,7 @@ name: Test TypeScript
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
+  NODE_VERSION: 20.x
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ https://taskfile.dev/#/installation
 Follow the installation instructions here:<br />
 https://nodejs.dev/en/download
 
-Node.js 16.x is used for development of this project. [nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
+Node.js 20.x is used for development of this project. [nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
 
 #### Extras
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,7 +220,8 @@ tasks:
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
-      INSTANCE_PATH: "**/package.json"
+      INSTANCE_PATH: >-
+        {{default "." .PROJECT_PATH}}/package.json
       PROJECT_FOLDER:
         sh: pwd
       WORKING_FOLDER:

--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,11 @@
       "devDependencies": {
         "@actions/io": "^1.1.3",
         "@types/jest": "^28.1.8",
+<<<<<<< HEAD
         "@types/node": "^16.18.79",
+=======
+        "@types/node": "^20.11.10",
+>>>>>>> bcbe36e (Update node version in package.json, actions and docs)
         "@types/semver": "^7.5.6",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
@@ -1633,10 +1637,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.79",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.79.tgz",
-      "integrity": "sha512-Qd7jdLR5zmnIyMhfDrfPqN5tUCvreVpP3Qrf2oSM+F7SNzlb/MwHISGUkdFHtevfkPJ3iAGyeQI/jsbh9EStgQ==",
-      "dev": true
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9075,6 +9082,12 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -10546,10 +10559,20 @@
       "dev": true
     },
     "@types/node": {
+<<<<<<< HEAD
       "version": "16.18.79",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.79.tgz",
       "integrity": "sha512-Qd7jdLR5zmnIyMhfDrfPqN5tUCvreVpP3Qrf2oSM+F7SNzlb/MwHISGUkdFHtevfkPJ3iAGyeQI/jsbh9EStgQ==",
       "dev": true
+=======
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
+>>>>>>> bcbe36e (Update node version in package.json, actions and docs)
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -16002,6 +16025,12 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,7 @@
       "devDependencies": {
         "@actions/io": "^1.1.3",
         "@types/jest": "^28.1.8",
-<<<<<<< HEAD
-        "@types/node": "^16.18.79",
-=======
-        "@types/node": "^20.11.10",
->>>>>>> bcbe36e (Update node version in package.json, actions and docs)
+        "@types/node": "^20.11.16",
         "@types/semver": "^7.5.6",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
@@ -1637,9 +1633,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
-      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "version": "20.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -10559,20 +10555,13 @@
       "dev": true
     },
     "@types/node": {
-<<<<<<< HEAD
-      "version": "16.18.79",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.79.tgz",
-      "integrity": "sha512-Qd7jdLR5zmnIyMhfDrfPqN5tUCvreVpP3Qrf2oSM+F7SNzlb/MwHISGUkdFHtevfkPJ3iAGyeQI/jsbh9EStgQ==",
-      "dev": true
-=======
-      "version": "20.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
-      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "version": "20.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
->>>>>>> bcbe36e (Update node version in package.json, actions and docs)
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@actions/io": "^1.1.3",
     "@types/jest": "^28.1.8",
-    "@types/node": "^20.11.10",
+    "@types/node": "^20.11.16",
     "@types/semver": "^7.5.6",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@actions/io": "^1.1.3",
     "@types/jest": "^28.1.8",
-    "@types/node": "^16.18.79",
+    "@types/node": "^20.11.10",
     "@types/semver": "^7.5.6",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",


### PR DESCRIPTION
Warnings are now being sent out due the deprecation of node16, node20 should be used for Github Actions.
This PR also update the `npm:validate` task based on @alessio-perugini's [comment below](https://github.com/arduino/setup-task/pull/919#issuecomment-1921243793).