### PR TITLE
Use versions of Task with Apple Silicon builds in tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -54,10 +54,18 @@ jobs:
         version:
           - input: 2.x
             expected: "Task version: 2.8.1"
-          - input: 2.8.x
-            expected: "Task version: 2.8.1"
-          - input: 3.4.1
-            expected: "Task version: 3.4.1"
+          - input: 3.36.x
+            expected: "Task version: v3.36.0 (h1:XVJ5hQ5hdzTAulHpAGzbUMUuYr9MUOEQFOFazI3hUsY=)"
+          - input: 3.37.2
+            expected: "Task version: v3.37.2 (h1:Jwgvo+2vX79Fu+44xPxVKC5DIkUE89QeDjN2tmYaQzA=)"
+
+        exclude:
+          # The macos-latest runner is an Apple Silicon machine, but Task 2.x is only available for x86 on macOS, which
+          # would cause a spurious test failure: "Unexpected HTTP response: 404"
+          - runs-on: macos-latest
+            version:
+              input: 2.x
+              expected: "Task version: 2.8.1"
 
     steps:
       - name: Checkout repository

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -43,8 +43,8 @@ describe("installer tests", () => {
   });
 
   it("Downloads version of Task if no matching version is installed", async () => {
-    await installer.getTask("2.6.0", "");
-    const taskDir = path.join(toolDir, "task", "2.6.0", os.arch());
+    await installer.getTask("3.37.1", "");
+    const taskDir = path.join(toolDir, "task", "3.37.1", os.arch());
 
     expect(fs.existsSync(`${taskDir}.complete`)).toBe(true);
 
@@ -67,9 +67,9 @@ describe("installer tests", () => {
       nock.enableNetConnect();
     });
 
-    it("Gets the latest version of Task 2.5 using 2.5 and no matching version is installed", async () => {
-      await installer.getTask("2.5", "");
-      const taskDir = path.join(toolDir, "task", "2.5.2", os.arch());
+    it("Gets the latest version of Task 3.36 using 3.36 and no matching version is installed", async () => {
+      await installer.getTask("3.36", "");
+      const taskDir = path.join(toolDir, "task", "3.36.0", os.arch());
 
       expect(fs.existsSync(`${taskDir}.complete`)).toBe(true);
       if (IS_WINDOWS) {
@@ -79,21 +79,9 @@ describe("installer tests", () => {
       }
     });
 
-    it("Gets latest version of Task using 2.x and no matching version is installed", async () => {
-      await installer.getTask("2.x", "");
-      const taskdir = path.join(toolDir, "task", "2.6.0", os.arch());
-
-      expect(fs.existsSync(`${taskdir}.complete`)).toBe(true);
-      if (IS_WINDOWS) {
-        expect(fs.existsSync(path.join(taskdir, "bin", "task.exe"))).toBe(true);
-      } else {
-        expect(fs.existsSync(path.join(taskdir, "bin", "task"))).toBe(true);
-      }
-    });
-
-    it("Gets preview version of Task using 3.x and no matching version is installed", async () => {
+    it("Gets latest version of Task using 3.x and no matching version is installed", async () => {
       await installer.getTask("3.x", "");
-      const taskdir = path.join(toolDir, "task", "3.0.0-preview1", os.arch());
+      const taskdir = path.join(toolDir, "task", "3.37.2", os.arch());
 
       expect(fs.existsSync(`${taskdir}.complete`)).toBe(true);
       if (IS_WINDOWS) {
@@ -104,8 +92,8 @@ describe("installer tests", () => {
     });
 
     it("Skips version computing when a valid semver is provided", async () => {
-      await installer.getTask("3.0.0", "");
-      const taskdir = path.join(toolDir, "task", "3.0.0", os.arch());
+      await installer.getTask("3.37.0", "");
+      const taskdir = path.join(toolDir, "task", "3.37.0", os.arch());
 
       expect(fs.existsSync(`${taskdir}.complete`)).toBe(true);
       if (IS_WINDOWS) {

--- a/__tests__/testdata/tags.json
+++ b/__tests__/testdata/tags.json
@@ -248,5 +248,35 @@
       "type": "tag",
       "url": "https://api.github.com/repos/go-task/task/git/tags/b637b3f832f28ce254377e507170c62cce3c20da"
     }
+  },
+  {
+    "ref": "refs/tags/v3.36.0",
+    "node_id": "MDM6UmVmODMyNTI5ODM6cmVmcy90YWdzL3YzLjM2LjA=",
+    "url": "https://api.github.com/repos/go-task/task/git/refs/tags/v3.36.0",
+    "object": {
+      "sha": "cc6d0979c6584edc68623aa67ffe29742baeaefe",
+      "type": "tag",
+      "url": "https://api.github.com/repos/go-task/task/git/tags/cc6d0979c6584edc68623aa67ffe29742baeaefe"
+    }
+  },
+  {
+    "ref": "refs/tags/v3.37.1",
+    "node_id": "MDM6UmVmODMyNTI5ODM6cmVmcy90YWdzL3YzLjM3LjE=",
+    "url": "https://api.github.com/repos/go-task/task/git/refs/tags/v3.37.1",
+    "object": {
+      "sha": "e48824e99dbccf39dc7d376c2684560945123b30",
+      "type": "tag",
+      "url": "https://api.github.com/repos/go-task/task/git/tags/e48824e99dbccf39dc7d376c2684560945123b30"
+    }
+  },
+  {
+    "ref": "refs/tags/v3.37.2",
+    "node_id": "MDM6UmVmODMyNTI5ODM6cmVmcy90YWdzL3YzLjM3LjI=",
+    "url": "https://api.github.com/repos/go-task/task/git/refs/tags/v3.37.2",
+    "object": {
+      "sha": "7aa90b1511c05da43f415d3e6b27aa9866cb40cb",
+      "type": "tag",
+      "url": "https://api.github.com/repos/go-task/task/git/tags/7aa90b1511c05da43f415d3e6b27aa9866cb40cb"
+    }
   }
 ]


### PR DESCRIPTION
The unit and integration tests install various versions of Task.

The GitHub Actions macos-latest runner was recently changed from using x86 machines to Apple Silicon/ARM machines:

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Task is now built for both architectures. However, this was not done for the older versions of Task previously used for the tests. The runner architecture switch caused the tests to start failing spuriously on the macos-latest GitHub Actions workflow run jobs:

https://github.com/arduino/setup-task/actions/runs/10205578962/job/28236648855#step:5:30

```text
FAIL __tests__/main.test.ts
  installer tests
    ✕ Downloads version of Task if no matching version is installed (188 ms)
    Gets the latest release of Task
      ✕ Gets the latest version of Task 2.5 using 2.5 and no matching version is installed (174 ms)
      ✕ Gets latest version of Task using 2.x and no matching version is installed (68 ms)
      ✕ Gets preview version of Task using 3.x and no matching version is installed (167 ms)
      ✕ Skips version computing when a valid semver is provided (164 ms)

  ● installer tests › Downloads version of Task if no matching version is installed

    Failed to download version v2.6.0: Error: Unexpected HTTP response: 404

      165 |       core.debug(error.toString());
      166 |     }
    > 167 |     throw new Error(`Failed to download version ${version}: ${error}`);
          |           ^
      168 |   }
      169 |
      170 |   // Extract

      at src/installer.ts:167:11
          at Generator.throw (<anonymous>)
      at rejected (src/installer.ts:40:65)

  ● installer tests › Gets the latest release of Task › Gets the latest version of Task 2.5 using 2.5 and no matching version is installed

    Failed to download version v2.5.2: Error: Unexpected HTTP response: 404

      165 |       core.debug(error.toString());
      166 |     }
    > 167 |     throw new Error(`Failed to download version ${version}: ${error}`);
          |           ^
      168 |   }
      169 |
      170 |   // Extract

      at src/installer.ts:167:11
          at Generator.throw (<anonymous>)
      at rejected (src/installer.ts:40:65)

  ● installer tests › Gets the latest release of Task › Gets latest version of Task using 2.x and no matching version is installed

    Failed to download version v2.6.0: Error: Unexpected HTTP response: 404

      165 |       core.debug(error.toString());
      166 |     }
    > 167 |     throw new Error(`Failed to download version ${version}: ${error}`);
          |           ^
      168 |   }
      169 |
      170 |   // Extract

      at src/installer.ts:167:11
          at Generator.throw (<anonymous>)
      at rejected (src/installer.ts:40:65)

  ● installer tests › Gets the latest release of Task › Gets preview version of Task using 3.x and no matching version is installed

    Failed to download version v3.0.0-preview1: Error: Unexpected HTTP response: 404

      165 |       core.debug(error.toString());
      166 |     }
    > 167 |     throw new Error(`Failed to download version ${version}: ${error}`);
          |           ^
      168 |   }
      169 |
      170 |   // Extract

      at src/installer.ts:167:11
          at Generator.throw (<anonymous>)
      at rejected (src/installer.ts:40:65)

  ● installer tests › Gets the latest release of Task › Skips version computing when a valid semver is provided

    Failed to download version v3.0.0: Error: Unexpected HTTP response: 404

      165 |       core.debug(error.toString());
      166 |     }
    > 167 |     throw new Error(`Failed to download version ${version}: ${error}`);
          |           ^
      168 |   }
      169 |
      170 |   // Extract

      at src/installer.ts:167:11
          at Generator.throw (<anonymous>)
      at rejected (src/installer.ts:40:65)
```

https://github.com/arduino/setup-task/actions/runs/10205578965/job/28236651388#step:3:6

```text
Error: Failed to download version v3.4.1: Error: Unexpected HTTP response: 404
```

The obvious solution would be to pin the runner to the last x86 runner: `macos-13` in the test runner workflows. However, GitHub phases out runners over time so this would not be a future proof solution. The chosen solution is to continue to use the Apple Silicon `macos-latest` runner and adjust the tests to use versions of Task for which an Apple Silicon build is available.

This was not possible for the integration test of the action's major version pinning capability. The reason is that a previous major version (2.x) must be used in this test in order to allow a consistent assertion, since the installed version would change over time if the latest major version was used. Apple Silicon builds are not available in the 2.x Task version series. For this reason, the integration test runner workflow is [configured to skip](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude) that test on the `macos-latest` runner job. The Linux and Windows integration test runner jobs, as well as unit test (which is not constrained in this way due to using [artificial tags data](https://github.com/arduino/setup-task/blob/main/__tests__/testdata/tags.json)) will provide sufficient coverage for this capability.