### PR TITLE
Bump "Licensed" version in dependency license check workflow

### DIFF
--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -77,7 +77,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -134,7 +134,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The version of the [**Licensed**](https://github.com/licensee/licensed) tool for use in the GitHub Actions workflow is defined via the **github/setup-licensed** action's `version` input.

Previously the action was configured to install version 3.x of the action. That version is significantly outdated. The workflow is hereby updated to use the latest version of **Licensed**.