### PR TITLE
Update format of dependency license metadata

### DIFF
--- a/.licenses/npm/function-bind.dep.yml
+++ b/.licenses/npm/function-bind.dep.yml
@@ -29,3 +29,4 @@ licenses:
     THE SOFTWARE.
 
 notices: []
+...

--- a/.licenses/npm/inherits.dep.yml
+++ b/.licenses/npm/inherits.dep.yml
@@ -3,7 +3,7 @@ name: inherits
 version: 2.0.4
 type: npm
 summary: Browser-friendly inheritance fully compatible with standard node.js inherits()
-homepage: 
+homepage:
 license: isc
 licenses:
 - sources: LICENSE

--- a/.licenses/npm/inherits.dep.yml
+++ b/.licenses/npm/inherits.dep.yml
@@ -25,3 +25,4 @@ licenses:
     PERFORMANCE OF THIS SOFTWARE.
 
 notices: []
+...

--- a/.licenses/npm/semver-6.3.0.dep.yml
+++ b/.licenses/npm/semver-6.3.0.dep.yml
@@ -3,7 +3,7 @@ name: semver
 version: 6.3.0
 type: npm
 summary: The semantic version parser used by npm.
-homepage: 
+homepage:
 license: isc
 licenses:
 - sources: LICENSE

--- a/.licenses/npm/semver-7.7.1.dep.yml
+++ b/.licenses/npm/semver-7.7.1.dep.yml
@@ -3,7 +3,7 @@ name: semver
 version: 7.7.1
 type: npm
 summary: The semantic version parser used by npm.
-homepage: 
+homepage:
 license: isc
 licenses:
 - sources: LICENSE


### PR DESCRIPTION
The [**Licensed**](https://github.com/licensee/licensed) tool is used to check for incompatible licenses in the project dependencies. The tool relies on a cache of metadata stored in the repository.

An older version of **Licensed** was in use at the time the cache was established. There are some minor differences in the format of the metadata generated by the version of **Licensed** currently in use.

Even though there is no technical significance to the format differences, they are disruptive in that they result in irrelevant diffs in specific metadata files when they are regenerated after a dependency bump. Rather than dealing with these diffs over time, it will be best to instead update the metadata to the new format comprehensively.