### PR TITLE
chore: bump Node.js runtime from 20 to 24

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ https://taskfile.dev/#/installation
 Follow the installation instructions here:<br />
 https://nodejs.dev/en/download
 
-Node.js 20.x is used for development of this project. [nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
+Node.js 24.x is used for development of this project. [nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
 
 #### Extras
 

--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     required: false
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@actions/io": "^2.0.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.42",
+        "@types/node": "^24.1.0",
         "@types/semver": "^7.7.1",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -39,7 +39,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": "20.x"
+        "node": "24.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1724,12 +1724,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -10756,9 +10757,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12467,12 +12468,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "requires": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "@types/normalize-package-data": {
@@ -18672,9 +18673,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true
     },
     "unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@actions/io": "^2.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.42",
+    "@types/node": "^24.1.0",
     "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
@@ -48,6 +48,6 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
Update **action.yml** to use `node24`, bump `@types/node` to `^24.1.0` (which pulls in `undici-types ~7.18.0`), set `engines.node` to `24.x` in **package.json**, and update the **CONTRIBUTING.md** version reference.

There is an [existing PR](https://github.com/arduino/setup-task/pull/1394) for this, but the collaborator did not sign the CLA and it's now over 3 weeks old.