### PR TITLE
Manually define dependency license metadata that was not detected

### DIFF
--- a/.licenses/npm/@actions/http-client-3.0.2.dep.yml
+++ b/.licenses/npm/@actions/http-client-3.0.2.dep.yml
@@ -4,7 +4,7 @@ version: 3.0.2
 type: npm
 summary: Actions Http Client
 homepage: https://github.com/actions/toolkit/tree/main/packages/http-client
-license: other
+license: mit
 licenses:
 - sources: LICENSE
   text: |


### PR DESCRIPTION
The "Licensed" dependency license checker tool uses the licensee tool to automatically determine the license type based on metadata provided by the dependency author. This must be in a standardized format without any modifications. In cases where that wasn't done, it is necessary to determine the license type and update the dependency license metadata cache in the `.licenses` folder manually.

The Licensed tool will check this data whenever the dependency version is updated to make sure the license hasn't changed.