### PR TITLE
Update major version ref in readme snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ To get the action's default version of Task just add this step:
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@v2
+  uses: arduino/setup-task@v3
 ```
 
 If you want to pin a major or minor version you can use the `.x` wildcard:
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@v2
+  uses: arduino/setup-task@v3
   with:
     version: 2.x
 ```
@@ -53,7 +53,7 @@ To pin the exact version:
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@v2
+  uses: arduino/setup-task@v3
   with:
     version: 2.6.1
 ```


### PR DESCRIPTION
Following the 3.0.0 release of the action, the current major version ref is now v3. The action usage example snippets in the project readme are hereby updated to demonstrate the use of that ref.