### PR TITLE
Add reference comment for Jest configuration

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,5 @@
+// See: https://kulshekhar.github.io/ts-jest/docs/guides/esm-support#using-esm-presets
+
 import type { Config } from "jest";
 import { createDefaultEsmPreset } from "ts-jest";
 


### PR DESCRIPTION
The project's unit tests are based on the Jest JavaScript test framework.

The ts-jest transformer allows testing of this TypeScript codebase with Jest. This requires a specific Jest configuration.

It will be beneficial to provide a link to ensure maintainers and contributors can find the reference information regarding this fairly complex configuration.