### PR TITLE
Remove deprecated formatting rules from ESLint configuration

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,20 +11,8 @@ parserOptions:
   project:
     - ./tsconfig.eslint.json
 rules:
-  max-len:
-    - error
-    - code: 180
-  "@typescript-eslint/comma-dangle": "off"
   no-console: "off"
-  padded-blocks: "off"
-  "@typescript-eslint/indent":
-    - error
-    - 2
-    - SwitchCase: 1
-  spaced-comment: warn
-  arrow-parens: "off"
   consistent-return: "off"
   no-useless-escape: "off"
   no-underscore-dangle: "off"
   import/prefer-default-export: "off"
-  "@typescript-eslint/type-annotation-spacing": error


### PR DESCRIPTION
**ESLint** has deprecated all formatting rules, and plans to remove support for them completely:

https://eslint.org/blog/2023/10/deprecating-formatting-rules/

**typescript-eslint** has followed suit:

https://typescript-eslint.io/blog/deprecating-formatting-rules

, and removed them in the 8.0.0 release:

https://typescript-eslint.io/blog/announcing-typescript-eslint-v8#rule-breaking-changes

These rules were almost entirely redundant to the code formatting style enforced for use in this project via **Prettier**. The only exception is [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment). However, this was only configured as a warning, so it was deemed not worthwhile to add a dependency on the [`@stylistic` plugin](https://eslint.style/) for this rule alone.