### PR TITLE
Configure `coverage` folder exclusion from development tools

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = afterall
-skip = ./.git,./dist,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./node_modules
+skip = ./.git,./coverage,./dist,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./node_modules
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+/coverage/
 dist
 lib
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/coverage/
+
 # Dependency directory
 node_modules/
 

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
+/coverage/
 # Dependency directory
 node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 /.licenses/
+/coverage/
 /dist/
 /lib/
 /node_modules/


### PR DESCRIPTION
The project's unit test infrastructure is configured to generate a code coverage report, which is saved under the `coverage` folder.

The sole purpose of this report is to allow the evaluation of code coverage for a given test run. The report is not checked into the repository. For this reason, all development tools that apply to the project files must be configured to exclude this folder.