### PR TITLE
Add exclusion for link causing spurious link check failure

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -7,6 +7,11 @@
       }
     }
   ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www\\.npmjs\\.com/"
+    }
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "aliveStatusCodes": [200, 206]


### PR DESCRIPTION
Links in the documentation files are validated using the [**markdown-link-check**](https://github.com/tcort/markdown-link-check) tool.

The documentation contains a link to the npm website. Unfortunately, even though the link is perfectly valid, this URL returns a 403 HTTP status to the link check tool. This caused the link check to fail spuriously. Spurious failures are problematic, both because they will result in a poor experience for contributors, and because they may cause the project maintainers to disregard failed checks, and thus possibly miss true positive detections.

The spurious failure is avoided by [configuring the link check tool](https://github.com/tcort/markdown-link-check#config-file-format) to ignore this specific link.