### PR TITLE
Install referenced schemas in `npm:validate` task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -200,6 +200,14 @@ tasks:
       JSCPD_SCHEMA_URL: https://json.schemastore.org/jscpd.json
       JSCPD_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/madge.json
+      MADGE_SCHEMA_URL: https://json.schemastore.org/madge.json
+      MADGE_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="madge-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/nodemon.json
+      NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
+      NODEMON_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/npm-badges.json
       NPM_BADGES_SCHEMA_URL: https://json.schemastore.org/npm-badges.json
       NPM_BADGES_SCHEMA_PATH:
@@ -212,6 +220,10 @@ tasks:
       PRETTIERRC_SCHEMA_URL: https://json.schemastore.org/prettierrc.json
       PRETTIERRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/quikrun.json
+      QUIKRUN_SCHEMA_URL: https://json.schemastore.org/quikrun.json
+      QUIKRUN_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="quikrun-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_PATH:
@@ -232,9 +244,12 @@ tasks:
       - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.MADGE_SCHEMA_PATH}}" {{.MADGE_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
       - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.QUIKRUN_SCHEMA_PATH}}" {{.QUIKRUN_SCHEMA_URL}}
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
@@ -246,9 +261,12 @@ tasks:
           -r "{{.BASE_SCHEMA_PATH}}" \
           -r "{{.ESLINTRC_SCHEMA_PATH}}" \
           -r "{{.JSCPD_SCHEMA_PATH}}" \
+          -r "{{.MADGE_SCHEMA_PATH}}" \
+          -r "{{.NODEMON_SCHEMA_PATH}}" \
           -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
           -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
           -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+          -r "{{.QUIKRUN_SCHEMA_PATH}}" \
           -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
           -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
           -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"


### PR DESCRIPTION
The `npm:validate` task  validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the `$ref` keyword. The `package.json` schema was recently updated to share resources with additional configuration schemas, which caused the validation to start failing.

The solution is to configure the task to download the missing schemas, and to pass their paths to the avj-cli validator.